### PR TITLE
Drop the php5-fpm naming convention in favor of just php-fpm

### DIFF
--- a/phpfpm/conf.sls
+++ b/phpfpm/conf.sls
@@ -3,7 +3,7 @@
 {% if webserver_edition == 'zendserver' %}
 {%- set req_pkg = 'zendserver' %}
 {%- else %}
-{%- set req_pkg = 'php5-fpm' %}
+{%- set req_pkg = 'php-fpm' %}
 {%- endif %}
 
 # Vanilla Ubuntu 14.04 packages

--- a/phpfpm/install.sls
+++ b/phpfpm/install.sls
@@ -3,7 +3,7 @@
 
 {% if php_versions|length == 0 and webserver_edition == 'vanilla' %}
 # Vanilla PHP 5.5 bundled with Ubuntu 14.04
-php5-fpm:
+php-fpm:
   pkg.installed: []
 {%- endif %}
 

--- a/phpfpm/lib.sls
+++ b/phpfpm/lib.sls
@@ -17,6 +17,6 @@
     {%- if php_version %}
       - service: php{{ php_version }}-fpm
     {%- else %}
-      - service: php5-fpm
+      - service: php-fpm
     {%- endif %}
 {% endmacro -%}

--- a/phpfpm/service.sls
+++ b/phpfpm/service.sls
@@ -3,14 +3,14 @@
 {% if webserver_edition == 'zendserver' %}
 {%- set watch_pkg = 'zendserver' %}
 {%- else %}
-{%- set watch_pkg = 'php5-fpm' %}
+{%- set watch_pkg = 'php-fpm' %}
 {%- endif %}
 
 extend:
 # Vanilla Ubuntu 14.04 packages
 {% if php_versions|length == 0 %}
 # Extend the php-fpm and ensure the service is running
-  php5-fpm:
+  php-fpm:
     service.running:
       - enable: True
       #- reload: True # disabled due to php-fpm upstream issues


### PR DESCRIPTION
Along with the [vhosting](https://github.com/Enrise/vhosting-formula/pull/42) and [zend server](https://github.com/Enrise/zendserver-formula/pull/5) formula this change drops the php5-fpm naming convention, replacing it by just php-fpm