### PR TITLE
Rework apt-pin for PHP7.3 on Xenial

### DIFF
--- a/phpfpm/files/apt-pin-ondrej-php
+++ b/phpfpm/files/apt-pin-ondrej-php
@@ -10,6 +10,6 @@ Pin: release o=LP-PPA-ondrej-php
 Pin-Priority: 500
 
 # Allow the dependency packages to be installed from Ondrej's repo
-Package: libpcre3
+Package: libpcre*
 Pin: release o=LP-PPA-ondrej-php
 Pin-Priority: 500


### PR DESCRIPTION
### What has been done
- Increased priority for all `libpcre` packages from the Surey repo rather than just `libpcre3` to prevent this from happening:
```
The following packages have unmet dependencies:
 php7.3-fpm : Depends: php7.3-cli but it is not going to be installed
              Depends: libpcre2-8-0 (>= 10.31) but 10.21-1 is to be installed
[ERROR   ] stderr: Running scope as unit run-r0a2fabec160a413bb4e15710377df3b8.scope.
E: Unable to correct problems, you have held broken packages.
``` 

Xenial (16.04) seems to be affected, didn't experience this problem at Bionic (18.04).