### PR TITLE
Allow libzip to be installed from ondrej repo

### DIFF
--- a/phpfpm/files/apt-pin-ondrej-php
+++ b/phpfpm/files/apt-pin-ondrej-php
@@ -13,3 +13,8 @@ Pin-Priority: 500
 Package: libpcre*
 Pin: release o=LP-PPA-ondrej-php
 Pin-Priority: 500
+
+# Allow the dependency packages to be installed from Ondrej's repo
+Package: libzip*
+Pin: release o=LP-PPA-ondrej-php
+Pin-Priority: 500


### PR DESCRIPTION
This PR fixes

```
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 php7.2-zip : Depends: libzip4 (>= 1.3.2) but 1.0.1-0ubuntu1 is to be installed
```