### PR TITLE
Fix extra_config setting in FPM Pools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
 - '2.7'
 
+dist: xenial
+
 env:
   global:
     - BS_PIP_ALLOWED=1

--- a/phpfpm/templates/pool.conf.jinja
+++ b/phpfpm/templates/pool.conf.jinja
@@ -24,7 +24,7 @@ pm.max_requests = {{ fpm_params.pm_max_requests|default(250) }}
 pm.status_path = {{ pm_status_path|default('/status') }}
 ping.path = {{ ping_path|default('/ping') }}
 
-{%- if extra_config is defined %}
+{% if fpm_params is defined and 'extra_config' in fpm_params %}
 ; Overrides
-{{ extra_config|join('\n') }}
+{{ fpm_params.extra_config|join('\n') }}
 {%- endif %}


### PR DESCRIPTION
### What has been done
- Moved `extra_config` from a standalone key (that didn't get passed on) to be part of `fpm_params`